### PR TITLE
Include schemas in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": {
     "katapult": "./bin/run"
   },
-  "bugs": "https://github.com/loop-os/katapult/issues",
+  "bugs": "https://github.com/product-os/katapult/issues",
   "dependencies": {
     "@oclif/command": "^1.5.12",
     "@oclif/config": "^1.12.10",
@@ -78,9 +78,10 @@
     "/bin",
     "/lib",
     "/npm-shrinkwrap.json",
-    "/oclif.manifest.json"
+    "/oclif.manifest.json",
+    "/schemas"
   ],
-  "homepage": "https://github.com/loop-os/katapult",
+  "homepage": "https://github.com/product-os/katapult",
   "keywords": [
     "oclif"
   ],
@@ -111,7 +112,7 @@
       "git add"
     ]
   },
-  "repository": "loop-os/katapult",
+  "repository": "product-os/katapult",
   "scripts": {
     "build": "tsc",
     "prettify": "prettier --config ./node_modules/resin-lint/config/.prettierrc --write \"src/**/*.ts\" \"typings/**/*.ts\" \"test/**/*.ts\"",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

- Include `/schemas` directory in deployed package contents
- Update repository name from `loop-os/` to `product-os/`

By including the `/schemas` directory in the end product, we will be able to execute `katapult` normally after installing with `npm i` and not require developers to clone -> build -> manually set alias to built code. By not including `/schemas`, the following error occurs:
```
$ npx katapult generate ...

    Error: Cannot find module '../../../../schemas/config-manifest-schema.json'
    Require stack:
    - /home/josh/git/product-os/example/node_modules/@balena/katapult/lib/lib/controllers/config-manifest/config-man


    ifest.js


    - /home/josh/git/product-os/example/node_modules/@balena/katapult/lib/commands/generate.js
    - /home/josh/git/product-os/example/node_modules/@oclif/config/lib/plugin.js
    - /home/josh/git/product-os/example/node_modules/@oclif/config/lib/config.js
    - /home/josh/git/product-os/example/node_modules/@oclif/config/lib/index.js
    - /home/josh/git/product-os/example/node_modules/@oclif/command/lib/command.js
    - /home/josh/git/product-os/example/node_modules/@oclif/command/lib/index.js
    - /home/josh/git/product-os/example/node_modules/@balena/katapult/bin/run
    Code: MODULE_NOT_FOUND
```